### PR TITLE
Add support for format to extract/bundle tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,31 +32,35 @@ Messages take one of two forms: string literals or JSX elements.
 A script is included that extracts messages from JSX files:
 
 ```
-$(npm bin)/extract-messages MyComponent.jsx > messages.json
+$(npm bin)/extract-messages MyComponent.jsx > messages.po
 ```
 
 You can operate on directories, and specify the output file:
 
 ```
-$(npm bin)/extract-messages -o messages.json src/
+$(npm bin)/extract-messages -o messages.po src/
 ```
 
 You can also merge with an existing file:
 
 ```
-$(npm bin)/extract-messages -m messages.json -o messages.json src/module/
+$(npm bin)/extract-messages -m messages.po -o messages.po src/module/
 ```
+
+The default output format is [`gettext` PO](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html), but you can also output JSON using the option `-f json`.
 
 
 ### Bundling translated messages
 
-Once you get your translations back from the translators (as `messages-fr.json`), you can use the `bundle-messages` script to generate a translations bundle:
+Once you get your translations back from the translators (as `messages-fr.po`), you can use the `bundle-messages` script to generate a translations bundle:
 
 ```
-$(npm bin)/bundle-messages -t messages-fr.json -o i18n/bundle-fr.js src/
+$(npm bin)/bundle-messages -t messages-fr.po -o i18n/bundle-fr.js src/
 ```
 
 This module exports an object that has translator functions for the corresponding locale.
+
+The default input format is determined by the file extension of the input file.
 
 
 ### Transforming the source

--- a/bin/bundle-messages.js
+++ b/bin/bundle-messages.js
@@ -5,9 +5,11 @@ require('babel-polyfill');
 var generate = require('babel-generator').default;
 
 function showHelpAndExit() {
-    console.log("Usage: bundle-messages -t TRANSLATIONS [-o OUTPUT] ...FILES/DIRECTORIES");
+    console.log("Usage: bundle-messages -t TRANSLATIONS [-o OUTPUT] [-f FORMAT (po|json)] ..FILES/DIRECTORIES");
     console.log("Prints a JS module with messages in FILES/DIRECTORIES mapped");
     console.log("to render functions.");
+    console.log("The input format automatically defaults to the file extension (po or json).")
+    console.log("Pass -f  to override this behavior.");
     console.log("If -o is passed, writes to OUTPUT instead of stdout.");
     process.exit();
 }
@@ -45,7 +47,7 @@ var missing = {};
 files.forEach(function (filename) {
     var buffer = fs.readFileSync(filename, "utf8");
     try {
-        var translationsForFile = translateMessagesToBundle(buffer, translations);
+        var translationsForFile = translateMessagesToBundle(buffer, translations, { inputFormat: format });
     } catch (e) {
         console.error(chalk.bold.red("\nError in file " + filename + ":"));
         console.error(e);

--- a/bin/extract-messages.js
+++ b/bin/extract-messages.js
@@ -4,15 +4,16 @@
 require('babel-polyfill');
 
 function showHelpAndExit() {
-    console.log("Usage: extract-messages [-m EXISTING] [-o OUTPUT] ...FILES/DIRECTORIES");
-    console.log("Prints a JSON document with messages in FILES/DIRECTORIES mapped to themselves.");
+    console.log("Usage: extract-messages [-m EXISTING] [-o OUTPUT] [-f FORMAT (po|json)]...FILES/DIRECTORIES");
+    console.log("Prints a document (gettext PO format by default) with messages in")
+    console.log("FILES/DIRECTORIES mapped to themselves.");
     console.log("If -o is passed, writes to OUTPUT instead of stdout.");
     process.exit();
 }
 
 var argv = require('minimist')(process.argv.slice(2), {
-    string: 'oh',
-    alias: {o: 'output', h: 'help'}
+    string: ['ohf'],
+    alias: {o: 'output', h: 'help', f: 'format'}
 });
 
 if (argv._.length === 0 || argv.h) {
@@ -25,7 +26,7 @@ var fs = require('fs');
 var filesFromMixedPaths = require('./filesFromMixedPaths');
 var extractFromPaths = require('../build/extract').default;
 
-var output = extractFromPaths(argv._);
+var output = extractFromPaths(argv._, { outputFormat: argv.f || 'po' });
 if (argv.o) {
     fs.writeFileSync(argv.o, output);
 } else {


### PR DESCRIPTION
I noticed that these weren't implemented and really wanted to use JSON, so I went ahead and added them and updated the help. I also updated the README to reflect the fact that JSON isn't the default format anymore.
