### PR TITLE
Add BooleanLiteral to noop list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,3 @@
 presentation*
-<<<<<<< HEAD
 node_modules*
 out*
-||||||| merged common ancestors
-=======
-node_modules*
->>>>>>> @{-1}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "walk": "^2.3.9"
   },
   "peerDependencies": {
+    "babel-polyfill": "^6.3.14",
     "react": "^0.14.0",
     "react-intl": "^2.0.0-beta-2"
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "walk": "^2.3.9"
   },
   "peerDependencies": {
-    "babel-polyfill": "^6.3.14",
     "react": "^0.14.0",
     "react-intl": "^2.0.0-beta-2"
   },

--- a/src/free-variables.js
+++ b/src/free-variables.js
@@ -100,6 +100,7 @@ function freeVariablesInExpression(expression, variables) {
         case 'Literal':
         case 'StringLiteral':
         case 'NumericLiteral':
+        case 'BooleanLiteral':
         case 'JSXEmptyExpression':
             // noop
         break;


### PR DESCRIPTION
I was getting console logs for React components that have attributes like `abc={true}`. Example:

```
Node {
  type: 'BooleanLiteral',
  start: 914,
  end: 918,
  loc: 
   SourceLocation {
     start: Position { line: 25, column: 84 },
     end: Position { line: 25, column: 88 } },
  value: true }
```

This prevents those logs.
