### PR TITLE
Fix lint config issue

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "es6": true,
         "browser": true,


### PR DESCRIPTION
I ran into an issue where I couldn’t get the linter to pass because it was merging in an .eslintrc file with different indentation settings that I had in the parent directory above the repo.

Adding “root” to the config will prevent it from crawling and grabbing any configs that might exist above the repo for whatever reason.
