### PR TITLE
Move state to context

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "es6": true,
         "browser": true,

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,10 +1,18 @@
-import {isElementMarker} from './ast';
+import {isElementMarker, isFunctionMarker} from './ast';
 import transformation from './transformation';
 
 
 module.exports = function() {
     return {
         visitor: {
+            CallExpression: {
+                enter: function(path) {
+                    const {node} = path;
+                    if (isFunctionMarker(node)) {
+                        path.replaceWith(transformation.transformFunctionMarker(node));
+                    }
+                }
+            },
             JSXElement: {
                 enter: function(path) {
                     const {node} = path;

--- a/test/test-transformation.js
+++ b/test/test-transformation.js
@@ -41,17 +41,17 @@ describe('Message node transformation', function() {
 
             [
                 "i18n('Well golly gee')",
-                "i18n('Well golly gee')"
+                "this.context._i18n('Well golly gee')"
             ],
 
             [
                 "i18n('Well \"golly\" gee')",
-                "i18n('Well \"golly\" gee')"
+                "this.context._i18n('Well \"golly\" gee')"
             ],
 
             [
                 "i18n('Well \\'golly\\' gee')",
-                "i18n('Well \\'golly\\' gee')"
+                "this.context._i18n('Well \\'golly\\' gee')"
             ]
         ]);
 


### PR DESCRIPTION
The shared state in components.jsx was causing me some trouble. In my isomorphic app, I wanted to be able to load the translated strings I needed dynamically at runtime when a page is requested, but components.jsx was storing the messages in a variable global to the module, which meant that that state was being shared across requests. It seemed to make more sense to me that the list of translations would be stored in a React context, which is a good mechanism for passing data down to child components.

In this branch, the way you set things up is to wrap your main app container in a parent component:

On the server:

```
let strings = require.context('../shared/translations/bundles', true, /.js$/)(`./${locale}.js`);

 let componentMarkup = renderToString(
     <I18NContainer messages={strings}>
        <RouterContext {...renderProps} />
    </I18NContainer>
);
```

And similarly in the entry point on the client:

```
 <I18NContainer messages={strings}>
    <Router history={browserHistory} routes={RootRoute} />
 </I18NContainer>
```

If you want to declare that you'd like one of your child components to receive the translation context, you can simply do this:

```
import React from 'react';

let { translated } = require('jsxlate/build/components').default;

class BaseComponent extends React.Component {
    componentWillMount() {
        // .. do some stuff
    }
}

BaseComponent.contextTypes = {
    existingContext: React.PropTypes.object.isRequired
};

export default translated(BaseComponent);
```

I think `translated` could easily be converted into an es2016 decorator as well. The reason for this function is to avoid having to declare the boilerplate `Class.contextTypes = { ... }` stuff every time you create a new component.

Finally, to be able to support `i18n('some text')`, the babel plugin replaces occurrences of that function with `this.context._i18n`. I realize this isn't ideal, because it requires `this` to refer to the component, and I'm sure that there's a cleaner way to do this but I haven't figured out what would be best yet. If you think this overall approach is interesting, I'd love to discuss this part of it more and make it less brittle.

I've tested this setup against my existing app and it's working pretty well. I'm sure there are some other approaches that could also work, but I wasn't able to come up with any other approach that would remove the global module-level state and keep it isolated. I'd love to hear your suggestions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/drd/jsxlate/13)
<!-- Reviewable:end -->
