### PR TITLE
Favor call message over element message on matches

### DIFF
--- a/build/translate.js
+++ b/build/translate.js
@@ -43,6 +43,9 @@ function translateMessagesToBundle(src, translationsSrc) {
 
     function attemptToCreateRenderer(node, message) {
         if (translations[message]) {
+            if ((0, _ast.isElementMarker)(node) && bundle[message]) {
+                return;
+            }
             bundle[message] = (0, _translation2.default)(node, translations[message], message);
         } else {
             missing[message] = message;

--- a/src/translate.js
+++ b/src/translate.js
@@ -23,6 +23,9 @@ export default function translateMessagesToBundle(src, translationsSrc, {inputFo
 
     function attemptToCreateRenderer(node, message) {
         if (translations[message]) {
+            if (isElementMarker(node) && bundle[message]) {
+                return;
+            }
             bundle[message] = translatedRendererFor(
                 node,
                 translations[message],

--- a/test/test-translation.js
+++ b/test/test-translation.js
@@ -22,7 +22,7 @@ describe('translation', function() {
             '<span:stat><ReactIntl.FormattedNumber /></span:stat>opportunities': '<span:stat><ReactIntl.FormattedNumber /></span:stat>oportunidades',
             '<Pluralize:items><Match when="=0">You have no items in your cart</Match><Match when="one">You have one item in your cart</Match><Match when="other">You have {this.state.count} items in your cart</Match></Pluralize:items>':
                 '<Pluralize:items><Match when="=0">No tiene nada in su carrito</Match><Match when="one">Tiene ún articulo en su carrito</Match><Match when="other">Tiene {this.state.count} articulos en su carrito</Match></Pluralize:items>',
-            'Hey': 'Hey'
+            'Hey': 'Hey',
         };
 
         var expectedResultsForTranslationBundles = {
@@ -40,7 +40,7 @@ describe('translation', function() {
             '<I18N><Re /><Ordering /></I18N>': 'function(Re, Ordering) { return <span><Ordering /><Re /></span>; }',
             '<I18N><Pluralize:items on={this.state.count}><Match when="=0">You have no items in your cart</Match><Match when="one">You have one item in your cart</Match><Match when="other">You have {this.state.count} items in your cart</Match></Pluralize:items></I18N>':
                 'function(Pluralize, Match) { return <span><Pluralize on={this.state.count}><Match when="=0">No tiene nada in su carrito</Match><Match when="one">Tiene ún articulo en su carrito</Match><Match when="other">Tiene {this.state.count} articulos en su carrito</Match></Pluralize></span>; }',
-            'i18n("Hey");<I18N>Hey</I18N>': 'function() { return "Hey"; }'
+            'i18n("Hey");<I18N>Hey</I18N>': 'function() { return "Hey"; }',
         };
 
         Object.keys(expectedResultsForTranslationBundles).forEach(original => {

--- a/test/test-translation.js
+++ b/test/test-translation.js
@@ -21,7 +21,8 @@ describe('translation', function() {
             'Check out: <Component />': '<Component/> "checked" out!',
             '<span:stat><ReactIntl.FormattedNumber /></span:stat>opportunities': '<span:stat><ReactIntl.FormattedNumber /></span:stat>oportunidades',
             '<Pluralize:items><Match when="=0">You have no items in your cart</Match><Match when="one">You have one item in your cart</Match><Match when="other">You have {this.state.count} items in your cart</Match></Pluralize:items>':
-                '<Pluralize:items><Match when="=0">No tiene nada in su carrito</Match><Match when="one">Tiene ún articulo en su carrito</Match><Match when="other">Tiene {this.state.count} articulos en su carrito</Match></Pluralize:items>'
+                '<Pluralize:items><Match when="=0">No tiene nada in su carrito</Match><Match when="one">Tiene ún articulo en su carrito</Match><Match when="other">Tiene {this.state.count} articulos en su carrito</Match></Pluralize:items>',
+            'Hey': 'Hey'
         };
 
         var expectedResultsForTranslationBundles = {
@@ -38,7 +39,8 @@ describe('translation', function() {
             '<I18N>Check out: <Component gnar={3 * shnar}/></I18N>': 'function(Component, shnar) { return <span><Component gnar={3 * shnar} /> "checked" out!</span>; }',
             '<I18N><Re /><Ordering /></I18N>': 'function(Re, Ordering) { return <span><Ordering /><Re /></span>; }',
             '<I18N><Pluralize:items on={this.state.count}><Match when="=0">You have no items in your cart</Match><Match when="one">You have one item in your cart</Match><Match when="other">You have {this.state.count} items in your cart</Match></Pluralize:items></I18N>':
-                'function(Pluralize, Match) { return <span><Pluralize on={this.state.count}><Match when="=0">No tiene nada in su carrito</Match><Match when="one">Tiene ún articulo en su carrito</Match><Match when="other">Tiene {this.state.count} articulos en su carrito</Match></Pluralize></span>; }'
+                'function(Pluralize, Match) { return <span><Pluralize on={this.state.count}><Match when="=0">No tiene nada in su carrito</Match><Match when="one">Tiene ún articulo en su carrito</Match><Match when="other">Tiene {this.state.count} articulos en su carrito</Match></Pluralize></span>; }',
+            'i18n("Hey");<I18N>Hey</I18N>': 'function() { return "Hey"; }'
         };
 
         Object.keys(expectedResultsForTranslationBundles).forEach(original => {


### PR DESCRIPTION
It is possible for `i18n("string")` and `<I18N>string</I18N>` to exist in the same project. If the element version is parsed by jsxlate _after_ the function call version, the bundle will contain:

``` js
{
  "string": function() { return <span>string</span>; }
}
```

when it should return:

``` js
{
  "string": function() { return "string"; }
}
```

because the result of the function call should be a string and not a React element. The jsxlate `<I18N>` component is smart enough to wrap the string in a `<span>` if it does not receive a React element from the translation renderer.

This PR fixes the issue by preferring the function-call renderer (which returns a string) over the jsx element renderer when their messages match.
